### PR TITLE
[35기 엄성훈] Add: AirCartPage 사용자 입력값 기능

### DIFF
--- a/public/data/aircartdata/airCartData.json
+++ b/public/data/aircartdata/airCartData.json
@@ -1,0 +1,72 @@
+{
+  "originResults": {
+    "code": "01023451212",
+    "airline": "대한항공",
+    "en_airline": "BOEING 789-9",
+    "kor_origin": "인천",
+    "kor_destination": "김포",
+    "origin": "인천 CJU",
+    "destination": "김포 GMP",
+    "flight_number": "YP0631",
+    "depDate": "2022.08.13(토)",
+    "arrDate": "2022.10.08(토)",
+    "depTime": "06:25",
+    "arrTime": "07:45",
+    "flight_time": "1시간 05분",
+    "user_information": {
+      "user_name": "홍길동",
+      "user_email": "ghdrlfehd@naver.com"
+    },
+    "person": 3,
+    "total_price": 118000,
+    "passengers": [
+      {
+        "name": "hogif Jeong",
+        "gender": "남성",
+        "birth": "2000-09-19",
+        "price": 59000
+      },
+      {
+        "name": "wiafw choi",
+        "gender": "남성",
+        "birth": "2002-10-10",
+        "price": 59000
+      }
+    ]
+  },
+  "destinationResults": {
+    "code": "01034242344",
+    "airline": "제주항공",
+    "en_airline": "BOEING 734-9",
+    "kor_origin": "인천",
+    "kor_destination": "김포",
+    "origin": "김포 GMP",
+    "destination": "인천 CJU",
+    "flight_number": "YP0503",
+    "depDate": "2022.08.14(토)",
+    "arrDate": "2022.10.08(토)",
+    "depTime": "06:30",
+    "arrTime": "07:40",
+    "flight_time": "1시간 10분",
+    "user_information": {
+      "user_name": "홍길동",
+      "user_email": "ghdrlfehd@naver.com"
+    },
+    "total_price": 208000,
+    "person": 3,
+    "passengers": [
+      {
+        "name": "efefefe Jeong",
+        "gender": "남성",
+        "birth": "2000-09-19",
+        "price": 59000
+      },
+      {
+        "name": "ewfwefwe choi",
+        "gender": "남성",
+        "birth": "2002-10-10",
+        "price": 59000
+      }
+    ]
+  }
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Footer from './components/Footer';
 import Nav from './components/Nav';
-import AirCart from './pages/AirCart';
+import AirCart from './pages/AirCart/AirCart';
 import AirList from './pages/AirList';
 import AirMain from './pages/AirMain/AirMain';
 import AirMap from './pages/AirMap';

--- a/src/pages/AirCart.js
+++ b/src/pages/AirCart.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const AirCart = () => {
-  return <div>AirCart</div>;
-};
-
-export default AirCart;

--- a/src/pages/AirCart/AirCart.js
+++ b/src/pages/AirCart/AirCart.js
@@ -1,0 +1,831 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import AirCartTicket from './AirCartTicket';
+import { AIR_TIKET_RES_USER_DATA } from './AirCartData';
+import { RetweetOutlined } from '@ant-design/icons';
+
+const AirCart = () => {
+  const [userData, setUserData] = useState([]);
+  const [bookData, setBookData] = useState({
+    booker_name: '',
+    booker_phone_number: '',
+    booker_email: '',
+  });
+  const [passengerData, setPassengerData] = useState([]);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch('/data/aircartdata/airCartData.json')
+      .then(res => res.json())
+      .then(data => {
+        setUserData(data);
+      });
+  }, []);
+
+  const { booker_name, booker_phone_number, booker_email } = bookData;
+
+  const PassengerDataArr = [];
+
+  Object.values(passengerData).map(object =>
+    PassengerDataArr.push({
+      first_name: object.first_name,
+      last_name: object.last_name,
+      gender: object.gender,
+      birthday: object.birthday,
+    })
+  );
+
+  const postUserData = e => {
+    alert(
+      `
+      예약자 정보
+      성함 : ${booker_name},
+      핸드폰 번호 : ${booker_phone_number},
+      이메일 : ${booker_email}
+
+      탑승객 정보
+      예약자 : ${passengerData[0].first_name}${passengerData[0].last_name}님
+      생년월일 : ${passengerData[0].birthday}
+      성별 : ${passengerData[0].gender}
+      국적 : ${passengerData[0].country}
+      예약해주셨습니다.
+      `
+    );
+
+    navigate('/');
+
+    // fetch(`data/data/data`, {
+    //   method: 'POST',
+    //   body: JSON.stringify({
+    //     booker_name: booker_name,
+    //     booker_phone_number: booker_phone_number,
+    //     booker_email: booker_email,
+    //     passengers: passengerData,
+    //   }),
+    // })
+    //   .then(res => res.json())
+    //   .then(result => {
+    //     if (result.access_token) {
+    //       navigate('/');
+    //     }
+    //   });
+  };
+
+  const handleInput = e => {
+    const { name, value } = e.target;
+    setBookData({ ...bookData, [name]: value });
+  };
+
+  // 확인을 위해 남겨둡니다.
+  // console.log(bookData);
+  // console.log(passengerData);
+
+  if (userData.length === 0) return <div>로딩중입니다.</div>;
+
+  const { originResults, destinationResults } = userData;
+
+  return (
+    <CartContainer>
+      <Contents>
+        <TitleDep2>선택한 항공편 확인</TitleDep2>
+        <SelectFlightWrap>
+          <FlightInner>
+            <TicketBox>
+              <TitAirSelect>
+                <DepTitle>{originResults.kor_origin}</DepTitle>
+                <RetweetOutlined />
+                <ArrTitle>{destinationResults.kor_destination} 항공편</ArrTitle>
+              </TitAirSelect>
+              <FlightListUl>
+                <AirCartTicket tiketData={originResults} />
+                <AirCartTicket tiketData={destinationResults} />
+              </FlightListUl>
+            </TicketBox>
+            <TiketBoxRes>
+              <ResSelect>예약자 정보</ResSelect>
+              <ResListUl>
+                {AIR_TIKET_RES_USER_DATA.map(data => {
+                  return (
+                    <ResListLi key={data.id}>
+                      <ResName onChange={handleInput}>
+                        <ResNameLabel>{data.title}</ResNameLabel>
+                        <ResNameWarp>
+                          <ResNameInput
+                            name={data.name}
+                            type={data.type}
+                            placeholder={data.placeholder}
+                          />
+                          <ResNameButton type="button">삭제</ResNameButton>
+                          <ResTxtInfo>{data.info}</ResTxtInfo>
+                        </ResNameWarp>
+                      </ResName>
+                    </ResListLi>
+                  );
+                })}
+              </ResListUl>
+            </TiketBoxRes>
+            <Passenger>
+              <PassengerInfo>
+                <PassengerTit>탑승객 정보</PassengerTit>
+                <PassengerSummon>탑승객 정보 불러오기</PassengerSummon>
+              </PassengerInfo>
+              <TabContent>
+                <TabUl>
+                  <TabLi>
+                    {[...Array(originResults.person)].map((n, idx) => {
+                      const handlePassengerData = e => {
+                        const { name, value } = e.target;
+                        setPassengerData({
+                          ...passengerData,
+                          [idx]: { ...passengerData[idx], [name]: value },
+                        });
+                      };
+                      return (
+                        <TabContentAdult
+                          key={idx}
+                          onChange={handlePassengerData}
+                        >
+                          <TabContentUserTit>성인 {idx + 1}</TabContentUserTit>
+                          <TabContentUl>
+                            <TabPassengeLi>
+                              <TabPassengeFrm>
+                                <TabPassengeNameLabel>
+                                  탑승객 성명
+                                </TabPassengeNameLabel>
+                                <TabPassengeNameWrap>
+                                  <ResFirstNameInput
+                                    type="text"
+                                    name="first_name"
+                                    placeholder="한글 성 (예:김)"
+                                  />
+                                  <ResLastNameInput
+                                    type="text"
+                                    name="last_name"
+                                    placeholder="한글 이름 (예:제주)"
+                                  />
+                                </TabPassengeNameWrap>
+                              </TabPassengeFrm>
+                            </TabPassengeLi>
+                            <TabPassengeLi>
+                              <TabPassengeFrm>
+                                <TabPassengeBirthLabel>
+                                  생년월일
+                                </TabPassengeBirthLabel>
+                                <TabPassengeBirthInput
+                                  name="birthday"
+                                  type="date"
+                                  placeholder="YYYY-MM-DD"
+                                />
+                                <TabPassengeSexWrap>
+                                  <TabPassengeSexLabel>
+                                    성별
+                                  </TabPassengeSexLabel>
+                                  <TabPassengeSexBox>
+                                    <TabPassengeSexMaleLabel>
+                                      남성
+                                    </TabPassengeSexMaleLabel>
+                                    <TabPassengeSexMale
+                                      type="radio"
+                                      name="gender"
+                                      value="male"
+                                    />
+                                    <TabPassengeSexWomanabel>
+                                      여성
+                                    </TabPassengeSexWomanabel>
+                                    <TabPassengeWoman
+                                      type="radio"
+                                      name="gender"
+                                      value="female"
+                                    />
+                                  </TabPassengeSexBox>
+                                </TabPassengeSexWrap>
+                              </TabPassengeFrm>
+                            </TabPassengeLi>
+                            <TabPassengeLi>
+                              <TabPassengeFrm>
+                                <TabPassengeNation>국적</TabPassengeNation>
+                                <TabPassengeNationWrap>
+                                  <TabPassengeNationInput
+                                    name="country"
+                                    type="text"
+                                    placeholder="대한민국"
+                                  />
+                                </TabPassengeNationWrap>
+                              </TabPassengeFrm>
+                            </TabPassengeLi>
+                          </TabContentUl>
+                        </TabContentAdult>
+                      );
+                    })}
+                  </TabLi>
+                </TabUl>
+              </TabContent>
+            </Passenger>
+          </FlightInner>
+          <PaymentBox>
+            <PaymentInfo>
+              <PaymentTit>결제정보</PaymentTit>
+              <PaymentSide>
+                <PaymentSideDep>가는편 요금</PaymentSideDep>
+                <PaymentSideDepAmount>
+                  {originResults.total_price.toLocaleString('ko-KR')}원
+                </PaymentSideDepAmount>
+              </PaymentSide>
+              <PaymentSide>
+                <PaymentSideArr>오는편 요금</PaymentSideArr>
+                <PaymentSideArrAmount>
+                  {destinationResults.total_price.toLocaleString('ko-KR')}원
+                </PaymentSideArrAmount>
+              </PaymentSide>
+              <PaymentSide>
+                <PaymentSideSumTit>결제금액</PaymentSideSumTit>
+                <PaymentSideAmount>
+                  {(
+                    originResults.total_price + destinationResults.total_price
+                  ).toLocaleString('ko-KR')}
+                  원
+                </PaymentSideAmount>
+              </PaymentSide>
+              <PaymentGuide>
+                <TitGuide>바로 결제해야 예약 확정</TitGuide>
+                <TitGuideInfo>
+                  시간이 경과될 경우 좌석이 매진되거나 요금이 변동될 수
+                  있습니다.
+                  <br />
+                  예약당시 금액과 결제 시 금액이 상이 할 수 있으며, 최종 금액은
+                  결제 페이지에서 확인하실 수 있습니다.
+                </TitGuideInfo>
+                <TitBtnArea>
+                  <AvailDetail>비행상세</AvailDetail>
+                  <AvailPrice>상세요금 보기</AvailPrice>
+                </TitBtnArea>
+              </PaymentGuide>
+            </PaymentInfo>
+            <PaymentBtns onClick={postUserData}>예 약</PaymentBtns>
+          </PaymentBox>
+        </SelectFlightWrap>
+      </Contents>
+    </CartContainer>
+  );
+};
+
+export default AirCart;
+
+const CartContainer = styled.div`
+  padding-top: 104px;
+  padding-bottom: 164px;
+  text-align: center;
+  background-color: #f7f7f7;
+`;
+
+const Contents = styled.div`
+  width: 1200px;
+  margin: 0 auto;
+  padding-top: 64px;
+  text-align: left;
+`;
+
+const TitleDep2 = styled.h2`
+  margin-bottom: 32px;
+  font-size: 20px;
+  line-height: 1.3;
+  font-weight: 900;
+`;
+
+const SelectFlightWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  min-height: 711px;
+`;
+
+const FlightInner = styled.div`
+  min-height: 711px;
+`;
+
+const TicketBox = styled.div`
+  padding: 32px;
+  border-radius: 16px;
+  background: #fff;
+`;
+const TiketBoxRes = styled.div`
+  margin-top: 24px;
+  padding: 32px;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+const ResSelect = styled.h3`
+  padding-bottom: 16px;
+  border-bottom: 1px dashed #eaeaea;
+  color: #202020;
+  font-size: 30px;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const ResListUl = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  margin: 15px 0 0 0;
+`;
+
+const ResListLi = styled.li`
+  width: 100%;
+  padding: 8px 0;
+  flex-direction: row;
+  vertical-align: top;
+`;
+
+const ResName = styled.form`
+  display: flex;
+`;
+
+const ResNameLabel = styled.label`
+  flex: 0 0 112px;
+  color: #404040;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 48px;
+  cursor: pointer;
+`;
+
+const ResNameWarp = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const ResNameInput = styled.input`
+  &::placeholder {
+    color: #cecece;
+    font-weight: 400;
+  }
+  width: 100%;
+  display: block;
+  padding-right: 50px;
+  min-width: 55px;
+  height: 48px;
+  padding: 0 15px;
+  color: #606060;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+`;
+
+const ResNameButton = styled.button`
+  position: absolute;
+  display: inline-block;
+  top: 1px;
+  right: 1px;
+  width: 46px;
+  height: 46px;
+  border: none;
+  background: quotes;
+  cursor: pointer;
+`;
+
+const ResTxtInfo = styled.p`
+  margin-top: 6px;
+  color: gray;
+  font-size: 14px;
+  line-height: 1.5;
+`;
+
+const TitAirSelect = styled.div`
+  padding-bottom: 16px;
+  border-bottom: 1px dashed #eaeaea;
+  color: #202020;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const DepTitle = styled.span`
+  margin-right: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed #eaeaea;
+  color: #202020;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const ArrTitle = styled.span`
+  margin-left: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed #eaeaea;
+  color: #202020;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const FlightListUl = styled.ul`
+  margin-top: 24px;
+`;
+
+const Passenger = styled.div`
+  margin-top: 16px;
+  padding: 32px;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+const PassengerInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px dashed #eaeaea;
+`;
+
+const PassengerTit = styled.h3`
+  padding-bottom: 16px;
+  color: #202020;
+  font-size: 28px;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const PassengerSummon = styled.a`
+  padding-bottom: 16px;
+  color: #202020;
+  font-size: 18px;
+  font-weight: 600;
+  text-decoration: underline;
+`;
+
+const TabContent = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+const TabUl = styled.ul`
+  display: flex;
+`;
+
+const TabLi = styled.li`
+  width: 100%;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 48px;
+  color: black;
+`;
+
+const PaymentBox = styled.div`
+  position: sticky;
+  top: 50px;
+  height: calc(100vh - 266px);
+  min-height: 453px;
+  width: 310px;
+  margin-left: 30px;
+`;
+
+const PaymentInfo = styled.div`
+  padding: 32px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 8px 16px 0 rgb(32 32 32 / 8%);
+  border: 1px solid #abccff;
+  margin-bottom: 16px;
+`;
+
+const PaymentTit = styled.h3`
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed #eaeaea;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const PaymentSide = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  line-height: 10px;
+`;
+
+const PaymentSideDep = styled.p`
+  color: #202020;
+  font-weight: 600;
+`;
+
+const PaymentSideDepAmount = styled.p`
+  color: #202020;
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+const PaymentSideArr = styled.p`
+  color: #202020;
+  font-weight: 600;
+`;
+const PaymentSideArrAmount = styled.p`
+  color: #202020;
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+const PaymentSideSumTit = styled.p`
+  color: #202020;
+  font-size: 19px;
+  font-weight: 800;
+`;
+
+const PaymentSideAmount = styled.p`
+  color: #63a1ff;
+  font-size: 19px;
+  font-weight: 800;
+`;
+
+const PaymentGuide = styled.div`
+  margin-top: 22px;
+  background: none;
+  padding: 30px 0 0 0;
+  border-top: 1px dashed #eaeaea;
+`;
+
+const TitGuide = styled.h4`
+  color: #202020;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 10px;
+`;
+
+const TitGuideInfo = styled.p`
+  color: #606060;
+  font-size: 14px;
+  line-height: 18px;
+`;
+
+const TitBtnArea = styled.div`
+  margin-top: 30px;
+  text-align: center;
+  font-size: 0;
+`;
+
+const AvailDetail = styled.button`
+  &:hover {
+    color: #fff;
+    background: #569aff;
+  }
+  display: block;
+  width: 100%;
+  min-width: 88px;
+  height: 48px;
+  padding: 0 24px;
+  color: #404040;
+  border: 1px solid #aeaeae;
+  background: #fff;
+  font-size: 16px;
+  border-radius: 8px;
+  line-height: 48px;
+  font-weight: 600;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+`;
+
+const AvailPrice = styled.button`
+  &:hover {
+    color: #fff;
+    background: #569aff;
+  }
+  display: block;
+  width: 100%;
+  min-width: 88px;
+  height: 48px;
+  margin-top: 8px;
+  padding: 0 24px;
+  color: #404040;
+  border: 1px solid #aeaeae;
+  background: #fff;
+  font-size: 16px;
+  border-radius: 8px;
+  line-height: 48px;
+  font-weight: 600;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+`;
+
+const PaymentBtns = styled.button`
+  display: block;
+  width: 100%;
+  color: #fff;
+  background: #569aff;
+  min-width: 224px;
+  height: 56px;
+  padding: 0 24px;
+  font-size: 20px;
+  border-radius: 12px;
+  line-height: 56px;
+  font-weight: 600;
+  text-align: center;
+  border: none;
+  box-shadow: 0 8px 16px 0rgba (32, 32, 32, 0.16);
+  cursor: pointer;
+`;
+
+const TabContentAdult = styled.form`
+  width: 100%;
+  padding: 8px 0;
+  flex-direction: row;
+  vertical-align: top;
+`;
+
+const TabContentUserTit = styled.p`
+  font-size: 20px;
+  font-weight: 900;
+`;
+
+const TabContentUl = styled.ul`
+  width: 100%;
+  padding: 8px 0;
+  flex-direction: row;
+  vertical-align: top;
+`;
+
+const TabPassengeLi = styled.li`
+  width: 100%;
+  padding: 8px 0;
+  flex-direction: row;
+  vertical-align: top;
+`;
+
+const TabPassengeFrm = styled.div`
+  display: flex;
+`;
+
+const TabPassengeNameLabel = styled.label`
+  flex: 0 0 112px;
+  color: #404040;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 48px;
+  cursor: pointer;
+`;
+
+const TabPassengeNameWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const ResFirstNameInput = styled.input`
+  &::placeholder {
+    color: #cecece;
+    font-weight: 400;
+  }
+  width: 49%;
+  display: block;
+  padding-right: 50px;
+  min-width: 55px;
+  height: 48px;
+  padding: 0 15px;
+  color: #606060;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+`;
+
+const ResLastNameInput = styled.input`
+  &::placeholder {
+    color: #cecece;
+    font-weight: 400;
+  }
+  width: 49%;
+  display: block;
+  padding-right: 50px;
+  min-width: 55px;
+  height: 48px;
+  padding: 0 15px;
+  color: #606060;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+`;
+
+const TabPassengeBirthLabel = styled.label`
+  flex: 0 0 112px;
+  color: #404040;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 48px;
+`;
+
+const TabPassengeBirthInput = styled.input`
+  &::placeholder {
+    color: #cecece;
+    font-weight: 400;
+  }
+  width: 60%;
+  display: block;
+  padding-right: 50px;
+  min-width: 55px;
+  height: 48px;
+  padding: 0 15px;
+  color: #606060;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+`;
+
+const TabPassengeSexWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const TabPassengeSexLabel = styled.label`
+  margin-left: 50px;
+  color: #404040;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 48px;
+`;
+
+const TabPassengeSexBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 60%;
+`;
+
+const TabPassengeSexMaleLabel = styled.label`
+  margin-right: 10px;
+  color: #404040;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 48px;
+`;
+
+const TabPassengeSexMale = styled.input`
+  width: 16px;
+  height: 16px;
+  display: block;
+  margin-right: 40px;
+  border: 1px solid #eaeaea;
+  font-size: 16px;
+  font-weight: 600;
+  color: #63a1ff;
+  border-color: #cde0ff;
+  background-color: #f4f9ff;
+  cursor: pointer;
+`;
+const TabPassengeSexWomanabel = styled.label`
+  margin-right: 10px;
+  color: #404040;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 48px;
+`;
+
+const TabPassengeWoman = styled.input`
+  width: 16px;
+  height: 16px;
+  display: block;
+  border: 1px solid #eaeaea;
+  font-size: 16px;
+  font-weight: 600;
+  color: black;
+  background-color: #ffffff;
+  cursor: pointer;
+`;
+
+const TabPassengeNation = styled.label`
+  flex: 0 0 112px;
+  color: #404040;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 48px;
+  cursor: pointer;
+`;
+
+const TabPassengeNationWrap = styled.div`
+  width: 100%;
+`;
+
+const TabPassengeNationInput = styled.input`
+  &::placeholder {
+    color: #cecece;
+    font-weight: 400;
+  }
+  width: 100%;
+  display: block;
+  padding: 0 15px;
+  color: #606060;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+`;

--- a/src/pages/AirCart/AirCartData.js
+++ b/src/pages/AirCart/AirCartData.js
@@ -1,0 +1,52 @@
+export const AIR_TIKET_RES_USER_DATA = [
+  {
+    id: 1,
+    name: 'booker_name',
+    title: '성명',
+    type: 'text',
+    placeholder: '실명입력',
+    info: '',
+  },
+  {
+    id: 2,
+    name: 'booker_phone_number',
+    title: '휴대전화번호',
+    type: 'number',
+    placeholder: '-빼고 숫자 입력',
+    info: '긴급상황 시 즉시 연락 가능한 번호를 정확히 입력해주세요.',
+  },
+  {
+    id: 3,
+    name: 'booker_email',
+    title: '이메일',
+    type: 'email',
+    placeholder: 'example@jejupass.com',
+    info: '위의 이메일로 예약확정 안내(바우처 등)가 전송됩니다.',
+  },
+];
+
+export const AIR_TIKET_RES_PASSENGER_DATA = [
+  {
+    id: 1,
+    title: '탑승객 성명',
+    type: 'text',
+    placeholderFirst: '한글 성(예:김)',
+    placeholderSecond: '한글 이름(예:제주)',
+  },
+  {
+    id: 2,
+    title: '생년월일',
+    type: 'number',
+    placeholder: 'YYYY.MM.DD',
+    info: '성별',
+    male: '남자',
+    female: '여자',
+  },
+  {
+    id: 3,
+    title: '국적',
+    type: 'text',
+    placeholder: '대한민국',
+    info: '위의 이메일로 예약확정 안내(바우처 등)가 전송됩니다.',
+  },
+];

--- a/src/pages/AirCart/AirCartTicket.js
+++ b/src/pages/AirCart/AirCartTicket.js
@@ -1,0 +1,216 @@
+import React from 'react';
+import styled from 'styled-components';
+import { WalletOutlined, RedoOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+
+const AirCartTicket = ({ tiketData }) => {
+  const navigate = useNavigate();
+
+  const goToAirList = () => {
+    navigate('/airlist');
+  };
+
+  const {
+    kor_origin,
+    depDate,
+    airline,
+    flight_number,
+    en_airline,
+    depTime,
+    origin,
+    arrTime,
+    destination,
+    total_price,
+    person,
+  } = tiketData;
+
+  return (
+    <FlightListli>
+      <TitleArea>
+        <TitleDep>
+          {kor_origin} 가는편
+          <TitleDepDate>{depDate}</TitleDepDate>
+        </TitleDep>
+        <TitleDepButton onClick={goToAirList}>
+          <RedoOutlined />
+        </TitleDepButton>
+      </TitleArea>
+      <SchResult>
+        <SchReusltAl>
+          <Air>
+            <Thumb>
+              <WalletOutlined />
+              <ThumbTitle>{airline}</ThumbTitle>
+            </Thumb>
+            <ThumbDepNum>{flight_number} |</ThumbDepNum>
+            <ThumbArrNum>{en_airline}</ThumbArrNum>
+          </Air>
+          <TimeInfo>
+            <TimeInfoTime>{depTime}</TimeInfoTime>
+            <TimeInfoPlace>{origin}</TimeInfoPlace>
+            <TimeInfoTime>{arrTime}</TimeInfoTime>
+            <TimeInfoPlace>{destination}</TimeInfoPlace>
+          </TimeInfo>
+          <InterInfo>
+            <InfoDay>총{person}인</InfoDay>
+            <InfoFightPirce>
+              {total_price.toLocaleString('ko-KR')}원
+            </InfoFightPirce>
+            <InfoRate>항공사별 초과 수화물 | </InfoRate>
+            <InfoRateCancel> 운임규정 및 취소 규정안내</InfoRateCancel>
+          </InterInfo>
+        </SchReusltAl>
+      </SchResult>
+    </FlightListli>
+  );
+};
+
+export default AirCartTicket;
+
+const FlightListli = styled.li`
+  margin-top: 24px;
+  border: 1px solid #eaeaea;
+  border-radius: 12px;
+`;
+
+const TitleArea = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 60px;
+  margin-bottom: 0;
+  padding: 0 24px;
+  background-color: #f8f8f8;
+`;
+
+const TitleDep = styled.h2`
+  font-size: 20px;
+  font-weight: 700;
+`;
+
+const TitleDepDate = styled.span`
+  display: inline-block;
+  padding-left: 10px;
+  color: gray;
+  font-weight: 600;
+  font-size: 20px;
+`;
+
+const TitleDepButton = styled.button`
+  display: block;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  outline: 0;
+  cursor: pointer;
+`;
+
+const SchResult = styled.div`
+  margin-top: 10px;
+  margin-bottom: 10px;
+`;
+
+const SchReusltAl = styled.div`
+  padding: 20px 24px;
+`;
+
+const Air = styled.div`
+  display: inline-block;
+  width: 260px;
+  vertical-align: top;
+  padding-right: 16px;
+`;
+
+const Thumb = styled.span`
+  display: block;
+`;
+
+const ThumbTitle = styled.span`
+  display: inline-block;
+  padding-left: 4px;
+  color: #202020;
+  font-size: 16px;
+  font-weight: 700;
+`;
+
+const ThumbDepNum = styled.span`
+  display: inline-block;
+  margin-top: 12px;
+  margin-right: 8px;
+  color: gray;
+  font-size: 16px;
+`;
+
+const ThumbArrNum = styled.span`
+  display: inline-block;
+  margin-top: 12px;
+  color: gray;
+  font-size: 16px;
+`;
+
+const TimeInfo = styled.div`
+  display: inline-block;
+  width: 160px;
+`;
+
+const TimeInfoTime = styled.span`
+  &:first-child {
+    margin-top: 0px;
+  }
+  display: inline-block;
+  margin-right: 6px;
+  color: #202020;
+  font-size: 16px;
+  font-weight: 700;
+  min-width: 52px;
+  margin-top: 8px;
+`;
+
+const TimeInfoPlace = styled.span`
+  color: gray;
+  font-size: 14px;
+`;
+
+const InterInfo = styled.div`
+  display: inline-block;
+  text-align: right;
+  width: 310px;
+  color: gray;
+  font-size: 14px;
+`;
+
+const InfoDay = styled.span`
+  &:first-child {
+    margin-top: 0px;
+    margin-right: 5px;
+  }
+  display: inline-block;
+  margin-top: 12px;
+  color: gray;
+  width: 150px;
+  font-size: 16px;
+  font-weight: 700;
+`;
+
+const InfoFightPirce = styled.span`
+  font-size: 14px;
+  color: #63a1ff;
+  width: 150px;
+  font-size: 16px;
+  font-weight: 900;
+`;
+
+const InfoRate = styled.span`
+  &:first-child {
+    margin-top: 0px;
+  }
+  display: inline-block;
+  margin-top: 12px;
+  width: 150px;
+  font-size: 14px;
+`;
+
+const InfoRateCancel = styled.span`
+  color: gray;
+  font-size: 14px;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 항공 예약(결제) 페이지 레이아웃, 예약자 입력값을 받는 기능구현

<br />

## :: 구현 사항 설명 
1. 상수데이터와 fetch함수를 사용하여, originResults 출발값과 destinationResults 도착값을 받아 화면에 여행티켓 정보를 랜더된다..
2. AirtCartTicket 컴포넌트에 props으로 originResults, destinationResults 값을 내려준다. 출발티켓과 도착티켓 정보가 랜더된다. 
3. destinationResults 컴포넌트에 예약자 본인의 정보를 넣고, 입력값을 받을 수 있도록 useState, [name]:value 를 사용, 입렶값을 저장한다.

<br />

## :: 성장 포인트 
- 백엔드와 통신과정에서 받아서 랜더하는 것과 유저 입렶 값을 다시 전송하는 과정에 대해 조금 더 생각할 수있는 시간을 가졌다.

<br />

## :: 기타 질문 및 특이 사항
- 컴포넌트를 비행티켓, 예약한 사람정보칸, 추가 탑승객칸, 총결제 금액정보(결제하기 버튼) 4가지 컴포넌트로 분리했는데,
- 컴포넌트를 다 분리해 두어서, <예약한 사람정보칸, 추가 탑승객칸, 총결제 금액정보(결제하기 버튼)> 한번에 관리 할 수가 없습니다.
- 3가지 정보를 결제하기 버튼을 통해 보내야하는데, 분리한 컴포넌트를 다시 합쳐야 할까요?
