### PR TITLE
[35기 엄성훈] Add: Kakao MAP API 레이아웃 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# API KEY
+.env

--- a/public/data/mapdata/mapData.json
+++ b/public/data/mapdata/mapData.json
@@ -1,0 +1,44 @@
+{
+  "message": [
+    {
+      "id": 1,
+      "name": "김포국제공항",
+      "price": "96000.00",
+      "region": "서울특별시",
+      "is_verified": true,
+      "latitude": "37.3325",
+      "longtitude": "126.4751",
+      "image_url": "https://images.unsplash.com/photo-1647483685653-6bb1537d69ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80"
+    },
+    {
+      "id": 2,
+      "name": "제주국제공항",
+      "price": "65000.00",
+      "region": "제주시",
+      "is_verified": false,
+      "latitude": "33.3044",
+      "longtitude": "126.2934",
+      "image_url": "https://images.unsplash.com/photo-1588611395188-fe6bc975ed50?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1473&q=80"
+    },
+    {
+      "id": 3,
+      "name": "김해국제공항",
+      "price": "160000.00",
+      "region": "부산광역시",
+      "is_verified": true,
+      "latitude": "35.17322",
+      "longtitude": "128.9464591",
+      "image_url": "https://images.unsplash.com/photo-1596516106788-98cd0f88bb1a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1032&q=80"
+    },
+    {
+      "id": 4,
+      "name": "양양국제공항",
+      "price": "90000.00",
+      "region": "강원도",
+      "is_verified": false,
+      "latitude": "38.0341",
+      "longtitude": "128.4009",
+      "image_url": "https://images.unsplash.com/photo-1558204692-5f402fe220b9?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80"
+    }
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAPS_API_KEY%"
+    ></script> -->
     <title>FreePass</title>
   </head>
   <body>

--- a/src/Router.js
+++ b/src/Router.js
@@ -5,7 +5,7 @@ import Nav from './components/Nav';
 import AirCart from './pages/AirCart';
 import AirList from './pages/AirList';
 import AirMain from './pages/AirMain/AirMain';
-import AirMap from './pages/AirMap';
+import AirMap from './pages/AirMap/AirMap';
 import Login from './pages/Login';
 import Main from './pages/Main';
 import Esg from './pages/Esg/Esg';

--- a/src/pages/AirMap/AirMap.js
+++ b/src/pages/AirMap/AirMap.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import LeftCont from './LeftCont';
+import RightCont from './RightCont';
+
+const AirMap = () => {
+  const [mapInfo, setMapInfo] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/mapdata/mapData.json')
+      .then(res => res.json())
+      .then(data => setMapInfo(data.message));
+  }, []);
+
+  const isData = mapInfo.length !== 0;
+
+  return !isData ? (
+    <h2>로딩중입니다....</h2>
+  ) : (
+    <AirMapContainer>
+      <LeftCont />
+      <RightCont mapInfo={mapInfo} />
+    </AirMapContainer>
+  );
+};
+
+export default AirMap;
+
+const AirMapContainer = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+`;

--- a/src/pages/AirMap/CustomOverlay.css
+++ b/src/pages/AirMap/CustomOverlay.css
@@ -1,0 +1,98 @@
+.overlayAirBox {
+  position: relative;
+  top: -110px;
+  width: 150px;
+  height: 180px;
+  padding: 5px 6px;
+  background-color: #fff;
+  border-radius: 16px;
+  border: 1px solid #abccff;
+  line-height: 1.3;
+  z-index: 5;
+  transition: 0.1s;
+}
+
+.overlayAirBox:hover {
+  transform: translateY(-10px);
+}
+
+.imgBox {
+  position: relative;
+  width: 100%;
+  height: 50%;
+  margin-bottom: 5px;
+}
+
+.overlayAirImg {
+  position: absolute;
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #abccff;
+  object-fit: cover;
+  box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.AirInfoWrap {
+  width: 100%;
+  padding: 5px;
+  text-align: center;
+}
+
+.AirName {
+  color: #404040;
+  font-size: 15px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 3px;
+}
+
+.AirRegion {
+  display: block;
+  color: #717171;
+  font-size: 14px;
+  margin-bottom: 3px;
+}
+
+.AirDesc {
+  display: block;
+  width: 100%;
+  color: #717171;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.AirPrice {
+  display: block;
+  color: #63a1ff;
+  font-size: 18px;
+  font-weight: 900;
+}
+
+.Arrow {
+  position: absolute;
+  left: 44%;
+  bottom: -8px;
+  width: 15px;
+  height: 15px;
+  background-color: #fff;
+  transform: rotate(45deg);
+  border-radius: 1px 0 1px 0;
+  border: solid #abccff;
+  border-width: 0 1px 1px 0;
+}
+
+.btView {
+  position: absolute;
+  left: 46%;
+  bottom: 82px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  background: #00cdd2;
+  box-shadow: 0 5px 5px rgb(0 0 0 / 10%);
+}

--- a/src/pages/AirMap/LeftCont.js
+++ b/src/pages/AirMap/LeftCont.js
@@ -1,0 +1,229 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { setBorder } from '../../styles/common';
+
+const LeftCont = () => {
+  return (
+    <LeftContWrap>
+      <TitleSearch>지도로 검색</TitleSearch>
+      <TitleInfo>여행일정</TitleInfo>
+      <SearchCondListUl>
+        <SearchCondListLi>
+          <StartTit>출발</StartTit>
+          <QuickSearch>
+            <FlightPanel>
+              <StartArea>서울 SEL</StartArea>
+              <StartArea>모든 지역</StartArea>
+              <InfoDateList>
+                <InfoData>탑승일정</InfoData>
+                <InfoWrap>
+                  <InfoInput type="text" placeholder="탑승일을 선택해주세요" />
+                </InfoWrap>
+                <InfoData>출발요일</InfoData>
+                <InfoWrap>
+                  <InfoInput
+                    type="text"
+                    placeholder="탑승요일을 선택해주세요"
+                  />
+                  <ListType>! 요일은 1개 이상 선택할 수 있어요</ListType>
+                </InfoWrap>
+                <InfoWeekWrap>
+                  {WEEK_DATA.map(weekData => {
+                    return (
+                      <InfoWeekBtn
+                        key={weekData.id}
+                        type="text"
+                        placeholder={weekData.name}
+                      />
+                    );
+                  })}
+                </InfoWeekWrap>
+              </InfoDateList>
+              <Link to="/">
+                <InfoNextBtn type="button">홈으로</InfoNextBtn>
+              </Link>
+            </FlightPanel>
+          </QuickSearch>
+        </SearchCondListLi>
+      </SearchCondListUl>
+    </LeftContWrap>
+  );
+};
+
+export default LeftCont;
+
+const LeftContWrap = styled.div`
+  width: 500px;
+  padding: 32px 24px;
+`;
+
+const TitleSearch = styled.h2`
+  margin-bottom: 56px;
+  font-size: 2rem;
+  line-height: 1.3;
+  font-family: NanumSquareR;
+  font-weight: 900;
+  color: #202020;
+`;
+
+const TitleInfo = styled.h3`
+  margin-bottom: 16px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.4;
+  color: #202020;
+`;
+
+const SearchCondListUl = styled.ul`
+  margin-top: 16px;
+`;
+
+const SearchCondListLi = styled.li`
+  margin-top: 16px;
+`;
+
+const StartTit = styled.p`
+  margin-bottom: 12px;
+  color: #404040;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;
+`;
+
+const QuickSearch = styled.div`
+  width: auto;
+`;
+
+const FlightPanel = styled.ul`
+  height: auto;
+  background: none;
+`;
+
+const StartArea = styled.li`
+  ${setBorder('1px solid #eaeaea;')};
+  height: 56px;
+  line-height: 56px;
+  text-align: left;
+  background-color: white;
+  position: relative;
+  padding: 0 15px;
+  margin-bottom: 5px;
+`;
+
+const InfoDateList = styled.li`
+  margin-top: 32px;
+`;
+
+const InfoData = styled.label`
+  margin-bottom: 12px;
+  color: #404040;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;
+  display: block;
+  margin-top: 32px;
+`;
+
+const InfoWrap = styled.div`
+  margin-top: 10px;
+`;
+
+const InfoInput = styled.input`
+  display: inline-block;
+  min-width: 55px;
+  height: 48px;
+  padding: 0 15px;
+  color: #606060;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  background: #fff;
+  width: 100%;
+`;
+
+const ListType = styled.p`
+  margin-top: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: gray;
+  line-height: 1.5;
+`;
+
+const InfoWeekWrap = styled.div`
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.1em;
+`;
+
+const InfoWeekBtn = styled.input`
+  min-width: 55px;
+  width: 24.6%;
+  height: 48px;
+  padding: 0 15px;
+  color: #63a1ff;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  border-color: #cde0ff;
+  background-color: #f4f9ff;
+  text-align: center;
+`;
+
+const InfoNextBtn = styled.button`
+  margin-top: 50px;
+  margin-left: 38%;
+  min-width: 55px;
+  width: 24.6%;
+  height: 48px;
+  padding: 0 15px;
+  color: #63a1ff;
+  line-height: 48px;
+  border-radius: 8px;
+  border: 1px solid #eaeaea;
+  border-color: #cde0ff;
+  background-color: #f4f9ff;
+  text-align: center;
+  font-weight: 900;
+  &:hover {
+    background-color: #63a1ff;
+    color: #ffffff;
+    font-weight: 800;
+  }
+`;
+
+const WEEK_DATA = [
+  {
+    id: 1,
+    name: '전체',
+  },
+  {
+    id: 2,
+    name: '월요일',
+  },
+  {
+    id: 3,
+    name: '화요일',
+  },
+  {
+    id: 4,
+    name: '수요일',
+  },
+  {
+    id: 5,
+    name: '목요일',
+  },
+  {
+    id: 6,
+    name: '금요일',
+  },
+  {
+    id: 7,
+    name: '토요일',
+  },
+  {
+    id: 8,
+    name: '일요일',
+  },
+];

--- a/src/pages/AirMap/RightCont.js
+++ b/src/pages/AirMap/RightCont.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from 'react';
+import './CustomOverlay.css';
+
+const RightCont = ({ mapInfo }) => {
+  const mapRef = useRef();
+  const { kakao } = window;
+
+  useEffect(() => {
+    const container = document.getElementById('jejuMap');
+    const options = {
+      center: new kakao.maps.LatLng(36.4185, 128.1557),
+      level: 13,
+    };
+    mapRef.current = new kakao.maps.Map(container, options);
+
+    const overlayInfos = mapInfo?.map(info => {
+      return {
+        title: info.name,
+        lat: info.latitude,
+        lng: info.longtitude,
+        img: info.image_url,
+        price: info.price,
+        region: info.region,
+        desc: info.description,
+      };
+    });
+
+    overlayInfos.forEach(data => {
+      let content = `<div class="overlayAirBox"><div class="imgBox"><img class="overlayAirImg" src=${
+        data.img
+      }/></div><div class="AirInfoWrap"><h2 class="AirName">${
+        data.title
+      }</h2><span class="AirRegion">${
+        data.region
+      }</span></span><strong class="AirPrice">${Number(
+        data.price
+      ).toLocaleString()}</strong></div><div class="Arrow"></div></div><div class="btView">`;
+
+      let position = new kakao.maps.LatLng(data.lat, data.lng);
+
+      let customOverlay = new kakao.maps.CustomOverlay({
+        position: position,
+        content: content,
+      });
+
+      customOverlay.setMap(mapRef.current);
+
+      // 지도 마커입니다. 예비용으로 두겠습니다.
+      // let markerPosition = new kakao.maps.LatLng(data.lat, data.lng);
+      // let marker = new kakao.maps.Marker({
+      //   position: markerPosition,
+      // });
+      // marker.setMap(mapRef.current);
+
+      <span class="AirDesc">${data.desc}</span>;
+    });
+  }, [kakao.maps.CustomOverlay, kakao.maps.LatLng, kakao.maps.Map, mapInfo]);
+
+  const isData = mapInfo.length !== 0;
+
+  return !isData ? (
+    <h2>로딩중입니다....</h2>
+  ) : (
+    <div
+      id="jejuMap"
+      style={{
+        width: '100%',
+        height: '100%',
+      }}
+    />
+  );
+};
+
+export default RightCont;

--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -1,0 +1,4 @@
+export const setBorder = (border, radius = '15px') => `
+  border: ${border};
+  border-radius: ${radius};
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- Mockup Data의 활용과 카카오 MAP API을 적용하여 Data 화면 랜더

<br />

## :: 구현 사항 설명 
- html / head 영역에 카카오 API Key 값을 넣는다. .env 환경변수파일에 키값을 적용하였다.
- useState, useEffect, fetch 함수로 Mockup Data의 값을 RightCon 컴포넌트에 props로 넘겨주었다.
- RightCon 컴포넌트에 useRef함수를 사용해 지도를 보여주는 kakao.mpas.Map 을 넣어 주었다.
- const overlayInfos = mapInfo?.map(data=>{{key: data.value}})로 새로운 객체를 부여해주었다.
-  overlayInfos.forEach를 통해 템플릿리터럴을 사용해 div data.img /div ~를 데이터 수만큼 화면에 랜더한다. 

<br />

## :: 성장 포인트 
- dotenv는 환경변수를 .env라는 파일에 저장하고 process.env로 로드하는 의존성 모듈이다.
- 이를 사용하는 이유로는 개발과정에서 사용되는 고유한 api key값 등 민감한 정보의 보안을 위해서다.
- 이를 올리지 않기위해서는 .gittignore에 추가하면 된다.
- 카카오맵 API도 마커를 찍는 일까지는 쉬웠지만, style-component 적용하는 방법과 커스터마이징 하는방법이
- 너무 어려웠지만, 그래도 잘 랜더하게 되었다. 

<br />

## :: 기타 질문 및 특이 사항
- html / head 부분의 주석부분은 카카오맵을 랜더를 임시적으로 막기위해 주석처리 해주었습니다.
